### PR TITLE
Avoid static variables - use ringbuf_reserve instead

### DIFF
--- a/ebpf/ebpf.c
+++ b/ebpf/ebpf.c
@@ -506,26 +506,28 @@ int udpgrm_setsockopt(struct bpf_sockopt *ctx)
 	if (ctx->optname == UDP_GRM_WORKING_GEN) {
 		int app_idx = s->sock_app % MAX_APPS;
 		{
-			int old = state->working_gen[app_idx];
-			state->working_gen[app_idx] = data->wrk.working_gen;
-
-			static struct msg_value e;
-			e.type = MSG_SET_WORKING_GEN;
-			e.app_idx = app_idx;
-			e.app_working_gen = data->wrk.working_gen;
-			_skey_from_bpf_sock(&e.skey, ctx->sk);
-
-			log_printfs(&e.skey, "[+] setting working gen %d (old=%d) (app=%d)\n", data->wrk.working_gen, old,
-				   app_idx);
-
-			unsigned ll = offsetof(struct msg_value, app_so_cookie) + 8;
-			int r = bpf_ringbuf_output(&msg_rb, &e, ll, 0);
-			if (r != 0) {
+			unsigned ev_size = offsetof(struct msg_value, app_so_cookie) + 8;
+			struct msg_value *event =
+				bpf_ringbuf_reserve(&msg_rb, ev_size, 0);
+			if (event == NULL) {
 				log_printf("[!] Error: rb failed: EGAIN\n");
 				// We don't incr critical metric as we return EGAIN
 				bpf_set_retval(-EAGAIN);
 				return 0;
 			}
+
+			int old = state->working_gen[app_idx];
+			state->working_gen[app_idx] = data->wrk.working_gen;
+
+			event->type = MSG_SET_WORKING_GEN;
+			event->app_idx = app_idx;
+			event->app_working_gen = data->wrk.working_gen;
+			_skey_from_bpf_sock(&event->skey, ctx->sk);
+
+			log_printfs(&event->skey, "[+] setting working gen %d (old=%d) (app=%d)\n",
+				   data->wrk.working_gen, old,
+				   app_idx);
+			bpf_ringbuf_submit(event, 0);
 		}
 
 		ctx->optlen = -1;
@@ -538,30 +540,32 @@ int udpgrm_setsockopt(struct bpf_sockopt *ctx)
 			// Socket gen is set to a new value or the socket is not yet
 			// registered. Post a message to udpgrm daemon to register with
 			// requested socket generation.
-			struct task_struct *ts = bpf_get_current_task_btf();
-
-			s->sock_gen = data->sk.socket_gen;
-
-			static struct msg_value e;
-			e.type = MSG_REGISTER_SOCKET;
-			e.pid = ts->pid;
-			e.socket_cookie = s->so_cookie;
-			e.socket_gen = data->sk.socket_gen;
-			e.socket_app = s->sock_app;
-			_skey_from_bpf_sock(&e.skey, ctx->sk);
-
-			log_printfs(&e.skey, "[+] registering socket ");
-			log_printf("so_cookie=0x%lx app=%d gen=%d pid=%d\n", s->so_cookie,
-				   s->sock_app, s->sock_gen, ts->pid);
-
-			unsigned ll = offsetof(struct msg_value, socket_app) + 8;
-			int r = bpf_ringbuf_output(&msg_rb, &e, ll, 0);
-			if (r != 0) {
+			unsigned ev_size = offsetof(struct msg_value, socket_app) + 8;
+			struct msg_value *event =
+				bpf_ringbuf_reserve(&msg_rb, ev_size, 0);
+			if (event == NULL) {
 				log_printf("[!] Error: rb failed, EGAIN\n");
 				// We don't incr critical metric as we return EGAIN
 				bpf_set_retval(-EAGAIN);
 				return 0;
 			}
+
+			struct task_struct *ts = bpf_get_current_task_btf();
+
+			s->sock_gen = data->sk.socket_gen;
+
+			event->type = MSG_REGISTER_SOCKET;
+			event->pid = ts->pid;
+			event->socket_cookie = s->so_cookie;
+			event->socket_gen = data->sk.socket_gen;
+			event->socket_app = s->sock_app;
+			_skey_from_bpf_sock(&event->skey, ctx->sk);
+
+			log_printfs(&event->skey, "[+] registering socket ");
+			log_printf("so_cookie=0x%lx app=%d gen=%d pid=%d\n", s->so_cookie,
+				   s->sock_app, s->sock_gen, ts->pid);
+
+			bpf_ringbuf_submit(event, 0);
 		}
 		ctx->optlen = -1;
 		bpf_set_retval(0);
@@ -627,26 +631,26 @@ int udpgrm_setsockopt(struct bpf_sockopt *ctx)
 			return 0;
 		}
 
-		memcpy(&state->dis, &data->dis, sizeof(struct udp_grm_dissector));
-		state->verbose = !!(data->dis.dissector_type & DISSECTOR_FLAG_VERBOSE);
-		state->dis.dissector_type = data->dis.dissector_type & ~DISSECTOR_FLAGS;
-
-		static struct msg_value e;
-		e.type = MSG_SET_DISSECTOR;
-		e.value = 0;
-		_skey_from_bpf_sock(&e.skey, ctx->sk);
-
-		log_printfs(&e.skey, "[+] setting dissector type %d\n",
-			   DISSECTOR_TYPE(data->dis.dissector_type));
-
-		unsigned ll = offsetof(struct msg_value, value) + 8;
-		int r = bpf_ringbuf_output(&msg_rb, &e, ll, 0);
-		if (r != 0) {
+		unsigned ev_size = offsetof(struct msg_value, value) + 8;
+		struct msg_value *event = bpf_ringbuf_reserve(&msg_rb, ev_size, 0);
+		if (event == NULL) {
 			log_printf("[!] Error: rb failed: EGAIN\n");
 			// We don't incr critical metric as we return EGAIN
 			bpf_set_retval(-EAGAIN);
 			return 0;
 		}
+
+		memcpy(&state->dis, &data->dis, sizeof(struct udp_grm_dissector));
+		state->verbose = !!(data->dis.dissector_type & DISSECTOR_FLAG_VERBOSE);
+		state->dis.dissector_type = data->dis.dissector_type & ~DISSECTOR_FLAGS;
+
+		event->type = MSG_SET_DISSECTOR;
+		event->value = 0;
+		_skey_from_bpf_sock(&event->skey, ctx->sk);
+
+		log_printfs(&event->skey, "[+] setting dissector type %d\n",
+			   DISSECTOR_TYPE(data->dis.dissector_type));
+		bpf_ringbuf_submit(event, 0);
 
 		ctx->optlen = -1;
 		bpf_set_retval(0);

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -73,11 +73,11 @@ class BasicTest(base.TestCase):
         wrk_gen = sa.getsockopt(IPPROTO_UDP, UDP_GRM_WORKING_GEN)
         sa.setsockopt(IPPROTO_UDP, UDP_GRM_SOCKET_GEN, wrk_gen + 1)
         self.assertIn("socket group created", p.stdout_line())
+        self.assertIn("socket found", p.stdout_line())
         self.assertIn("registering socket", p.stdout_line())
         sa.setsockopt(IPPROTO_UDP, UDP_GRM_WORKING_GEN, wrk_gen + 1)
-        self.assertIn("socket found", p.stdout_line())
-        self.assertIn("setting working gen", p.stdout_line())
         self.assertIn("Working gen", p.stdout_line())
+        self.assertIn("setting working gen", p.stdout_line())
 
     def test_abi_check_loaded_daemon(self):
         ''' returns proto 92 with no loaded ebpf, and -1 with loaded '''
@@ -202,8 +202,8 @@ class BasicTest(base.TestCase):
         p.cont()
 
         self.assertIn('socket group created', p.stdout_line())
-        self.assertIn('registering socket', p.stdout_line())
         self.assertIn('socket found', p.stdout_line())
+        self.assertIn('registering socket', p.stdout_line())
         self.sync_socket_gen(sd, prev=0xffa1)
 
         # now socket gen = 1 and socket idx = 1
@@ -216,9 +216,9 @@ class BasicTest(base.TestCase):
 
         v = sd.getsockopt(IPPROTO_UDP, UDP_GRM_SOCKET_GEN, 12)
         self.assertEqual(v, struct.pack('III', 31, 0, 0x7f))
-        self.assertIn('registering socket', p.stdout_line())
         self.assertIn('weird', p.stdout_line())
         self.assertIn('socket found', p.stdout_line())
+        self.assertIn('registering socket', p.stdout_line())
         v = sd.getsockopt(IPPROTO_UDP, UDP_GRM_SOCKET_GEN, 12)
         self.assertEqual(v, struct.pack('III', 31, 0, 0x7f))
 

--- a/tools/udpgrm_activate.py
+++ b/tools/udpgrm_activate.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/bin/env -S python3 -u
 from systemd.daemon import notify
 import argparse
 import errno


### PR DESCRIPTION
We used static variables, and mutated them in couple of places, to save on stack. This is wrong and racey. Instead rely on ringbuf_reserve.